### PR TITLE
Devon's uncommitted changes

### DIFF
--- a/src/GlyphGenerator.js
+++ b/src/GlyphGenerator.js
@@ -34,7 +34,7 @@ export default class GlyphGenerator {
       let glyphRun = run.attributes.font.layout(str, run.attributes.features, run.attributes.script);
       let end = glyphIndex + glyphRun.glyphs.length;
 
-      let res = new GlyphRun(glyphIndex, end, run.attributes, glyphRun);
+      let res = new GlyphRun(glyphIndex, end, run.attributes, glyphRun.glyphs, glyphRun.positions, glyphRun.stringIndices);
       this.resolveAttachments(res);
 
       glyphIndex = end;
@@ -81,10 +81,10 @@ export default class GlyphGenerator {
     }
 
     for (let i = 0; i < glyphRun.length; i++) {
-      let glyph = glyphRun.run.glyphs[i];
-      let position = glyphRun.run.positions[i];
+      let glyph = glyphRun.glyphs[i];
+      let position = glyphRun.positions[i];
       if (glyph.codePoints[0] === Attachment.CODEPOINT) {
-        position.xAdvance = attachment.width / glyphRun.scale;
+        position.xAdvance = attachment.width;
       }
     }
   }

--- a/src/JustificationEngine.js
+++ b/src/JustificationEngine.js
@@ -60,9 +60,11 @@ export default class JustificationEngine {
     }
 
     let factors = [];
+    let start = 0;
     for (let run of line.glyphRuns) {
       // let engine = run.font._justEngine;
-      factors.push(...this.factor(run.run.glyphs, gap > 0 ? 'GROW' : 'SHRINK'));
+      factors.push(...this.factor(line, start, run.glyphs, gap > 0 ? 'GROW' : 'SHRINK'));
+      start += run.glyphs.length;
     }
 
     factors[0].before = 0;
@@ -74,14 +76,13 @@ export default class JustificationEngine {
 
     let index = 0;
     for (let run of line.glyphRuns) {
-      let scale = 1 / run.scale;
-      for (let position of run.run.positions) {
-        position.xAdvance += distances[index++] * scale;
+      for (let position of run.positions) {
+        position.xAdvance += distances[index++];
       }
     }
   }
 
-  factor(glyphs, direction) {
+  factor(line, start, glyphs, direction) {
     if (direction === 'GROW') {
       var charFactor = _.clone(EXPAND_CHAR_FACTOR);
       var whitespaceFactor = _.clone(EXPAND_WHITESPACE_FACTOR);
@@ -93,7 +94,7 @@ export default class JustificationEngine {
     let factors = [];
     for (let index = 0; index < glyphs.length; index++) {
       let glyph = glyphs[index];
-      if (unicode.isWhiteSpace(glyph.codePoints[0])) {
+      if (line.isWhiteSpace(start + index)) {
         var factor = _.clone(whitespaceFactor);
 
         if (index === glyphs.length - 1) {

--- a/src/LineFragmentGenerator.js
+++ b/src/LineFragmentGenerator.js
@@ -48,11 +48,14 @@ export default class LineFragmentGenerator {
       let contour = polygon.contours[i];
       let index = -1;
       let state = -1;
+
+      // Find the first point outside the line rect.
       do {
         let point = contour[++index];
         state = point.y <= minY ? BELOW : point.y >= maxY ? ABOVE : INSIDE;
       } while (state === INSIDE && index < contour.length - 1);
 
+      // Contour is entirely inside the line rect. Skip it.
       if (state === INSIDE) {
         continue;
       }

--- a/src/TabEngine.js
+++ b/src/TabEngine.js
@@ -22,10 +22,10 @@ const ALIGN_TERMINATORS = {
 export default class TabEngine {
   processLineFragment(glyphString, container) {
     for (let {glyph, position, run, x, index} of glyphString) {
-      if (glyph.codePoints[0] === TAB) {
+      if (glyphString.codePointAtGlyphIndex(index) === TAB) {
         // Find the next tab stop and adjust x-advance
         let tabStop = this.getTabStopAfter(container, x);
-        position.xAdvance = (tabStop.x - x) / run.scale;
+        position.xAdvance = (tabStop.x - x);
 
         // Adjust based on tab stop alignment
         let terminator = ALIGN_TERMINATORS[tabStop.align];
@@ -38,7 +38,7 @@ export default class TabEngine {
             nextX += glyphString.getGlyphWidth(next) / 2;
           }
 
-          position.xAdvance -= (nextX - tabStop.x) / run.scale * ALIGN_FACTORS[tabStop.align];
+          position.xAdvance -= (nextX - tabStop.x) * ALIGN_FACTORS[tabStop.align];
         }
       }
     }

--- a/src/TextDecorationEngine.js
+++ b/src/TextDecorationEngine.js
@@ -68,14 +68,14 @@ export default class TextDecorationEngine {
         continue;
       }
 
-      for (let i = 0; i < run.run.glyphs.length; i++) {
-        let position = run.run.positions[i];
+      for (let i = 0; i < run.glyphs.length; i++) {
+        let position = run.positions[i];
 
         if (x >= line.rect.x && x <= line.rect.maxX) {
-          let gx = x + position.xOffset * run.scale;
-          let gy = y + position.yOffset * run.scale;
+          let gx = x + position.xOffset;
+          let gy = y + position.yOffset;
 
-          let path = run.run.glyphs[i].path
+          let path = run.glyphs[i].path
             .scale(run.scale, -run.scale)
             .translate(gx, gy);
 
@@ -85,8 +85,8 @@ export default class TextDecorationEngine {
           }
         }
 
-        x += position.xAdvance * run.scale;
-        y += position.yAdvance * run.scale;
+        x += position.xAdvance;
+        y += position.yAdvance;
       }
     }
 

--- a/src/TextRenderer.js
+++ b/src/TextRenderer.js
@@ -1,4 +1,5 @@
 import Attachment from './models/Attachment';
+import Rect from './geom/Rect';
 
 /**
  * A TextRenderer renders text layout objects to a graphics context.
@@ -38,7 +39,12 @@ export default class TextRenderer {
     this.ctx.scale(1, -1, {});
 
     for (let run of line.glyphRuns) {
-      this.renderRun(run);
+      if (run.attributes.backgroundColor) {
+        let backgroundRect = new Rect(0, line.descent, run.advanceWidth, line.height);
+        this.renderBackground(backgroundRect, run.attributes.backgroundColor);
+      }
+
+      this.renderRun(run, line);
     }
 
     this.ctx.restore();
@@ -53,10 +59,12 @@ export default class TextRenderer {
     this.ctx.restore();
   }
 
-  renderRun(run) {
+  renderRun(run, line) {
     if (this.outlineRuns) {
       this.ctx.rect(0, 0, run.advanceWidth, run.height).stroke();
     }
+
+    this.ctx.fillColor(run.attributes.color);
 
     let x = 0, y = 0;
 
@@ -77,6 +85,11 @@ export default class TextRenderer {
 
       this.ctx.translate(position.xAdvance * run.scale, position.yAdvance * run.scale);
     }
+  }
+
+  renderBackground(rect, backgroundColor) {
+    this.ctx.rect(rect.x, rect.y, rect.width, rect.height);
+    this.ctx.fill(backgroundColor);
   }
 
   renderAttachment(attachment) {

--- a/src/TruncationEngine.js
+++ b/src/TruncationEngine.js
@@ -25,7 +25,7 @@ export default class TruncationEngine {
     let run = lineFragment.runAtGlyphIndex(glyphIndex);
     let font = run.attributes.font;
     let ellipsisGlyph = font.glyphForCodePoint(ELLIPSIS);
-    let ellipsisWidth = ellipsisGlyph.advanceWidth * run.scale;
+    let ellipsisWidth = ellipsisGlyph.advanceWidth;
 
     while (lineFragment.advanceWidth + ellipsisWidth > lineFragment.rect.width) {
       let nextGlyph;

--- a/src/Typesetter.js
+++ b/src/Typesetter.js
@@ -31,6 +31,10 @@ export default class Typesetter {
   }
 
   layoutLineFragments(lineRect, glyphString, container, paragraphStyle) {
+    // Guess the line height using the full line before intersecting with the container.
+    lineRect.height = glyphString.slice(0, glyphString.glyphIndexAtOffset(lineRect.width)).height;
+
+    // Generate line fragment rectangles by intersecting with the container.
     let fragmentRects = this.lineFragmentGenerator.generateFragments(lineRect, container);
     if (fragmentRects.length === 0) {
       return [];

--- a/src/models/GlyphString.js
+++ b/src/models/GlyphString.js
@@ -99,6 +99,15 @@ export default class GlyphString {
     return height;
   }
 
+  get descent() {
+    let height = 0;
+    for (let run of this.glyphRuns) {
+      height = Math.min(height, run.descent);
+    }
+
+    return height;
+  }
+
   *[Symbol.iterator]() {
     let x = 0;
     for (let run of this.glyphRuns) {

--- a/src/models/ParagraphStyle.js
+++ b/src/models/ParagraphStyle.js
@@ -10,6 +10,7 @@ export default class ParagraphStyle {
     this.alignLastLine = attributes.alignLastLine || 'left';
     this.justificationFactor = attributes.justificationFactor || 1;
     this.hyphenationFactor = attributes.hyphenationFactor || 0;
+    this.shrinkFactor = attributes.shrinkFactor || 0;
     this.lineSpacing = attributes.lineSpacing || 0;
     this.hangingPunctuation = attributes.hangingPunctuation || false;
     this.truncationMode = attributes.truncationMode || (attributes.truncate ? 'right' : null);

--- a/src/models/RunStyle.js
+++ b/src/models/RunStyle.js
@@ -3,6 +3,7 @@ import FontDescriptor from './FontDescriptor';
 export default class RunStyle {
   constructor(attributes = {}) {
     this.color = attributes.color || 'black';
+    this.backgroundColor = attributes.backgroundColor || null;
     this.fontDescriptor = FontDescriptor.fromAttributes(attributes);
     this.font = attributes.font || null;
     this.fontSize = attributes.fontSize || 12;

--- a/temp.js
+++ b/temp.js
@@ -76,7 +76,7 @@ doc.stroke();
 let string = AttributedString.fromFragments([
   {
     string: '“Lorem ipsum dolor sit \ufffc amet, ',
-    attributes: {font: 'Hoefler Text', fontSize: 14, bold: true, align: 'justify', hyphenationFactor: 0.9, hangingPunctuation: true, lineSpacing: 5, underline: true, underlineStyle: 'wavy', underlineColor: 'red', truncate: true, attachment: new Attachment(50, 50, {image: '/Users/devongovett/Downloads/Slack for iOS Upload (1).jpg'})}
+    attributes: {font: 'Hoefler Text', fontSize: 14, bold: true, align: 'justify', hyphenationFactor: 0.9, hangingPunctuation: true, lineSpacing: 5, underline: true, underlineStyle: 'wavy', underlineColor: 'red', truncate: true}
   },
   {
     string: 'consectetur adipiscing elit, ',
@@ -110,7 +110,7 @@ let l = new LayoutEngine;
 let container = new Container(path, {
   exclusionPaths: [exclusion],
   tabStops: [new TabStop(100, 'decimal'), new TabStop(150, 'left'), new TabStop(250, 'right')],
-  columns: 2
+  // columns: 2
 });
 let container2 = new Container(path2);
 l.layout(string, [container]);


### PR DESCRIPTION
@diegomura Here are my uncommitted changes that weren't on master. Unfortunately, there is something not quite working - will require some debugging.

I believe I was in the process of changing GlyphString and GlyphRun to use proper string indices generated by fontkit. There is a fontkit branch called [string-index](https://github.com/devongovett/fontkit/compare/string-index) which returns an array of the correct string indices for each glyph. This is necessary since glyphs can be reordered, and we need a way to map glyph indices back to string indices and visa versa. Also, since it is stored in a lookup table, it should be much faster for textkit to look up.

Also in here, the text renderer calls a new PDFKit API to render glyphs as text in the pdf. That can be found on the [textkit](https://github.com/devongovett/pdfkit/compare/textkit) branch of PDFKit.

Looks like a few other things are in here too, like changing a bunch of the scaling code to be in the text renderer instead of everywhere else. This might be the cause of some of the breakage.

Obviously there is still a lot of work to do to get all of this working, but I thought I'd put it up so we can get started from this baseline before refactoring the code again.