### PR TITLE
Resolve glyph indices outside

### DIFF
--- a/packages/core/src/layout/GlyphGenerator.js
+++ b/packages/core/src/layout/GlyphGenerator.js
@@ -29,6 +29,7 @@ export default class GlyphGenerator {
         run.attributes.script
       );
       const end = glyphIndex + glyphRun.glyphs.length;
+      const glyphIndices = this.resolveGlyphIndices(str, glyphRun.stringIndices);
 
       const res = new GlyphRun(
         glyphIndex,
@@ -36,7 +37,8 @@ export default class GlyphGenerator {
         run.attributes,
         glyphRun.glyphs,
         glyphRun.positions,
-        glyphRun.stringIndices
+        glyphRun.stringIndices,
+        glyphIndices
       );
 
       this.resolveAttachments(res);
@@ -47,6 +49,25 @@ export default class GlyphGenerator {
     });
 
     return new GlyphString(attributedString.string, glyphRuns);
+  }
+
+  resolveGlyphIndices(string, stringIndices) {
+    const glyphIndices = [];
+
+    for (let i = 0; i < string.length; i++) {
+      glyphIndices[i] = stringIndices[i];
+    }
+
+    let lastValue = 0;
+    for (let i = glyphIndices.length - 1; i >= 0; i--) {
+      if (glyphIndices[i] === undefined) {
+        glyphIndices[i] = lastValue;
+      } else {
+        lastValue = glyphIndices[i];
+      }
+    }
+
+    return glyphIndices;
   }
 
   resolveRuns(attributedString) {

--- a/packages/core/src/layout/GlyphGenerator.js
+++ b/packages/core/src/layout/GlyphGenerator.js
@@ -55,11 +55,27 @@ export default class GlyphGenerator {
     const glyphIndices = [];
 
     for (let i = 0; i < string.length; i++) {
-      glyphIndices[i] = stringIndices[i];
+      for (let j = 0; j < stringIndices.length; j++) {
+        if (stringIndices[j] >= i) {
+          glyphIndices[i] = j;
+          break;
+        }
+
+        glyphIndices[i] = undefined;
+      }
     }
 
-    let lastValue = 0;
+    let lastValue = glyphIndices[glyphIndices.length - 1];
     for (let i = glyphIndices.length - 1; i >= 0; i--) {
+      if (glyphIndices[i] === undefined) {
+        glyphIndices[i] = lastValue;
+      } else {
+        lastValue = glyphIndices[i];
+      }
+    }
+
+    lastValue = glyphIndices[0];
+    for (let i = 0; i < glyphIndices.length; i++) {
       if (glyphIndices[i] === undefined) {
         glyphIndices[i] = lastValue;
       } else {

--- a/packages/core/src/layout/Typesetter.js
+++ b/packages/core/src/layout/Typesetter.js
@@ -42,7 +42,9 @@ export default class Typesetter {
     for (const fragmentRect of fragmentRects) {
       const line = glyphString.slice(pos, glyphString.length);
 
-      this.tabEngine.processLineFragment(line, container);
+      if (this.tabEngine) {
+        this.tabEngine.processLineFragment(line, container);
+      }
 
       const bk = this.lineBreaker.suggestLineBreak(line, fragmentRect.width, paragraphStyle);
 

--- a/packages/core/src/models/GlyphRun.js
+++ b/packages/core/src/models/GlyphRun.js
@@ -24,11 +24,11 @@ class GlyphRun extends Run {
   }
 
   get stringStart() {
-    return 0;
+    return Math.min(...this.stringIndices);
   }
 
   get stringEnd() {
-    return this.glyphIndices.length - 1;
+    return Math.max(...this.stringIndices);
   }
 
   get advanceWidth() {
@@ -66,9 +66,9 @@ class GlyphRun extends Run {
     const glyphs = this.glyphs.slice(start, end);
     const positions = this.positions.slice(start, end);
     let stringIndices = this.stringIndices.slice(start, end);
-    let glyphIndices = this.glyphIndices.slice(this.stringIndices[start], this.stringIndices[end]);
+    let glyphIndices = this.glyphIndices.filter(i => i >= start && i < end);
 
-    glyphIndices = glyphIndices.map(index => index - this.glyphIndices[stringIndices[0]]);
+    glyphIndices = glyphIndices.map(index => index - start);
     stringIndices = stringIndices.map(index => index - this.stringIndices[start]);
 
     start += this.start;

--- a/packages/core/src/models/GlyphRun.js
+++ b/packages/core/src/models/GlyphRun.js
@@ -3,11 +3,12 @@ import Run from './Run';
 class GlyphRun extends Run {
   constructor(start, end, attributes, glyphs, positions, stringIndices, glyphIndices, preScaled) {
     super(start, end, attributes);
+
     this.glyphs = glyphs || [];
     this.positions = positions || [];
+    this.glyphIndices = glyphIndices || [];
     this.stringIndices = stringIndices || [];
     this.scale = attributes.fontSize / attributes.font.unitsPerEm;
-    this.glyphIndices = glyphIndices;
 
     if (!preScaled) {
       for (const pos of this.positions) {

--- a/packages/core/src/models/GlyphRun.js
+++ b/packages/core/src/models/GlyphRun.js
@@ -1,13 +1,13 @@
 import Run from './Run';
 
 class GlyphRun extends Run {
-  constructor(start, end, attributes, glyphs, positions, stringIndices, preScaled) {
+  constructor(start, end, attributes, glyphs, positions, stringIndices, glyphIndices, preScaled) {
     super(start, end, attributes);
     this.glyphs = glyphs || [];
     this.positions = positions || [];
     this.stringIndices = stringIndices || [];
     this.scale = attributes.fontSize / attributes.font.unitsPerEm;
-    this._glyphIndices = null;
+    this.glyphIndices = glyphIndices;
 
     if (!preScaled) {
       for (const pos of this.positions) {
@@ -23,36 +23,12 @@ class GlyphRun extends Run {
     return this.end - this.start;
   }
 
-  get glyphIndices() {
-    if (this._glyphIndices) {
-      return this._glyphIndices;
-    }
-
-    const glyphIndices = [];
-
-    for (let i = 0; i < this.stringIndices.length; i++) {
-      glyphIndices[this.stringIndices[i]] = i;
-    }
-
-    let lastValue = 0;
-    for (let i = glyphIndices.length - 1; i >= 0; i--) {
-      if (glyphIndices[i] === undefined) {
-        glyphIndices[i] = lastValue;
-      } else {
-        lastValue = glyphIndices[i];
-      }
-    }
-
-    this._glyphIndices = glyphIndices;
-    return glyphIndices;
-  }
-
   get stringStart() {
-    return Math.min(...this.stringIndices);
+    return 0;
   }
 
   get stringEnd() {
-    return Math.max(...this.stringIndices);
+    return this.glyphIndices.length - 1;
   }
 
   get advanceWidth() {
@@ -90,14 +66,25 @@ class GlyphRun extends Run {
     const glyphs = this.glyphs.slice(start, end);
     const positions = this.positions.slice(start, end);
     let stringIndices = this.stringIndices.slice(start, end);
+    let glyphIndices = this.glyphIndices.slice(this.stringIndices[start], this.stringIndices[end]);
 
+    glyphIndices = glyphIndices.map(index => index - this.glyphIndices[stringIndices[0]]);
     stringIndices = stringIndices.map(index => index - this.stringIndices[start]);
 
     start += this.start;
     end += this.start;
     end = Math.min(end, this.end);
 
-    return new GlyphRun(start, end, this.attributes, glyphs, positions, stringIndices, true);
+    return new GlyphRun(
+      start,
+      end,
+      this.attributes,
+      glyphs,
+      positions,
+      stringIndices,
+      glyphIndices,
+      true
+    );
   }
 
   copy() {
@@ -108,6 +95,7 @@ class GlyphRun extends Run {
       this.glyphs,
       this.positions,
       this.stringIndices,
+      this.glyphIndices,
       true
     );
   }

--- a/packages/core/src/models/GlyphString.js
+++ b/packages/core/src/models/GlyphString.js
@@ -222,10 +222,10 @@ class GlyphString {
       }
 
       offset += run.length;
-      count += run.stringEnd + 1;
+      count += run.glyphIndices.length;
     }
 
-    return count + run.stringIndices[run.stringIndices.length - 1];
+    return count;
   }
 
   glyphIndexForStringIndex(index) {
@@ -319,6 +319,13 @@ class GlyphString {
 
     run.glyphs.splice(glyphIndex, 0, glyph);
     run.stringIndices.splice(glyphIndex, 0, run.stringIndices[glyphIndex]);
+
+    for (let i = 0; i < run.glyphIndices.length; i++) {
+      if (run.glyphIndices[i] >= glyphIndex) {
+        run.glyphIndices[i] += 1;
+      }
+    }
+
     run.positions.splice(glyphIndex, 0, {
       xAdvance: glyph.advanceWidth * scale,
       yAdvance: 0,
@@ -348,6 +355,12 @@ class GlyphString {
     run.glyphs.splice(glyphIndex, 1);
     run.positions.splice(glyphIndex, 1);
     run.stringIndices.splice(glyphIndex, 1);
+
+    for (let i = 0; i < run.glyphIndices.length; i++) {
+      if (run.glyphIndices[i] >= glyphIndex) {
+        run.glyphIndices[i] -= 1;
+      }
+    }
 
     run.end--;
 

--- a/packages/core/test/models/GlyphRun.test.js
+++ b/packages/core/test/models/GlyphRun.test.js
@@ -239,11 +239,25 @@ describe('GlyphRun', () => {
     expect(stringIndices).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
+  test('should correctly slice glyph indices', () => {
+    const glyphRun = createLatinTestRun({ value: 'Lorem Ipsum' });
+    const { glyphIndices } = glyphRun.slice(2, 8);
+
+    expect(glyphIndices).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
   test('should correctly slice string indices (non latin)', () => {
     const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
     const { stringIndices } = glyphRun.slice(1, 8);
 
     expect(stringIndices).toEqual([0, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test('should correctly slice glyph indices (non latin)', () => {
+    const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
+    const { glyphIndices } = glyphRun.slice(1, 8);
+
+    expect(glyphIndices).toEqual([0, 1, 1, 2, 3, 4, 5, 6]);
   });
 
   test('should exact slice return same string indices', () => {

--- a/packages/core/test/models/GlyphRun.test.js
+++ b/packages/core/test/models/GlyphRun.test.js
@@ -239,11 +239,25 @@ describe('GlyphRun', () => {
     expect(stringIndices).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
+  test('should correctly slice glyph indices', () => {
+    const glyphRun = createLatinTestRun({ value: 'Lorem Ipsum' });
+    const { glyphIndices } = glyphRun.slice(2, 8);
+
+    expect(glyphIndices).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
   test('should correctly slice string indices (non latin)', () => {
     const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
     const { stringIndices } = glyphRun.slice(1, 8);
 
     expect(stringIndices).toEqual([0, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test('should correctly slice glyph indices (non latin)', () => {
+    const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
+    const { glyphIndices } = glyphRun.slice(1, 8);
+
+    expect(glyphIndices).toEqual([0, 1, 1, 2, 3, 4, 5, 6]);
   });
 
   test('should exact slice return same string indices', () => {
@@ -253,10 +267,46 @@ describe('GlyphRun', () => {
     expect(stringIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
+  test('should exact slice return same glyph indices', () => {
+    const glyphRun = createLatinTestRun({ value: 'Lorem Ipsum' });
+    const { glyphIndices } = glyphRun.slice(0, 11);
+
+    expect(glyphIndices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
   test('should exact slice return same string indices (non latin)', () => {
     const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
     const { stringIndices } = glyphRun.slice(0, 21);
 
     expect(stringIndices).toEqual([0, 1, 3, 4, 5, 6, 7, 8, 12, 13, 14, 16, 17, 18, 19, 20]);
+  });
+
+  test('should exact slice return same glyph indices (non latin)', () => {
+    const glyphRun = createCamboyanTestRun({ value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន' });
+    const { glyphIndices } = glyphRun.slice(0, 21);
+
+    expect(glyphIndices).toEqual([
+      0,
+      1,
+      2,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      8,
+      8,
+      8,
+      9,
+      10,
+      11,
+      11,
+      12,
+      13,
+      14,
+      15
+    ]);
   });
 });

--- a/packages/core/test/models/GlyphString.test.js
+++ b/packages/core/test/models/GlyphString.test.js
@@ -616,17 +616,20 @@ describe('GlyphString', () => {
     expect(string.glyphIndexForStringIndex(10)).toBe(10);
   });
 
-  test('should return correct glyph index for string index (not latin)', () => {
+  test.only('should return correct glyph index for string index (not latin)', () => {
     const string = createCamboyanTestString({
       value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន',
       runs: [[0, 8], [8, 21]]
     });
 
-    expect(string.glyphIndexForStringIndex(0)).toBe(0);
-    expect(string.glyphIndexForStringIndex(4)).toBe(3);
-    expect(string.glyphIndexForStringIndex(7)).toBe(6);
-    expect(string.glyphIndexForStringIndex(8)).toBe(7);
-    expect(string.glyphIndexForStringIndex(12)).toBe(8);
+    // console.log(string.string);
+    // console.log(string.glyphRuns);
+
+    // expect(string.glyphIndexForStringIndex(0)).toBe(0);
+    // expect(string.glyphIndexForStringIndex(4)).toBe(3);
+    // expect(string.glyphIndexForStringIndex(7)).toBe(6);
+    // expect(string.glyphIndexForStringIndex(8)).toBe(7);
+    // expect(string.glyphIndexForStringIndex(12)).toBe(8);
   });
 
   test('should return correct glyph index for string index for sliced strings', () => {

--- a/packages/core/test/models/GlyphString.test.js
+++ b/packages/core/test/models/GlyphString.test.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import { createLatinTestString, createCamboyanTestString } from '../utils/glyphStrings';
 
 const round = num => Math.round(num * 100) / 100;
@@ -616,20 +615,17 @@ describe('GlyphString', () => {
     expect(string.glyphIndexForStringIndex(10)).toBe(10);
   });
 
-  test.only('should return correct glyph index for string index (not latin)', () => {
+  test('should return correct glyph index for string index (not latin)', () => {
     const string = createCamboyanTestString({
       value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន',
       runs: [[0, 8], [8, 21]]
     });
 
-    // console.log(string.string);
-    // console.log(string.glyphRuns);
-
-    // expect(string.glyphIndexForStringIndex(0)).toBe(0);
-    // expect(string.glyphIndexForStringIndex(4)).toBe(3);
-    // expect(string.glyphIndexForStringIndex(7)).toBe(6);
-    // expect(string.glyphIndexForStringIndex(8)).toBe(7);
-    // expect(string.glyphIndexForStringIndex(12)).toBe(8);
+    expect(string.glyphIndexForStringIndex(0)).toBe(0);
+    expect(string.glyphIndexForStringIndex(4)).toBe(3);
+    expect(string.glyphIndexForStringIndex(7)).toBe(6);
+    expect(string.glyphIndexForStringIndex(8)).toBe(7);
+    expect(string.glyphIndexForStringIndex(12)).toBe(8);
   });
 
   test('should return correct glyph index for string index for sliced strings', () => {

--- a/packages/core/test/models/GlyphString.test.js
+++ b/packages/core/test/models/GlyphString.test.js
@@ -559,6 +559,38 @@ describe('GlyphString', () => {
     expect(string.stringIndexForGlyphIndex(10)).toBe(10);
   });
 
+  test('should return correct string index for glyph index with ligatures (end)', () => {
+    const string = createLatinTestString({
+      value: 'Lorft ipsum',
+      runs: [[0, 5], [5, 11]]
+    });
+
+    expect(string.isWhiteSpace(3)).toBeFalsy();
+    expect(string.isWhiteSpace(4)).toBeTruthy();
+    expect(string.stringIndexForGlyphIndex(0)).toBe(0);
+    expect(string.stringIndexForGlyphIndex(2)).toBe(2);
+    expect(string.stringIndexForGlyphIndex(3)).toBe(3);
+    expect(string.stringIndexForGlyphIndex(4)).toBe(5);
+    expect(string.stringIndexForGlyphIndex(5)).toBe(6);
+    expect(string.stringIndexForGlyphIndex(9)).toBe(10);
+  });
+
+  test('should return correct string index for glyph index with ligatures (middle)', () => {
+    const string = createLatinTestString({
+      value: 'Lftem ipsum',
+      runs: [[0, 5], [5, 11]]
+    });
+
+    expect(string.isWhiteSpace(3)).toBeFalsy();
+    expect(string.isWhiteSpace(4)).toBeTruthy();
+    expect(string.stringIndexForGlyphIndex(0)).toBe(0);
+    expect(string.stringIndexForGlyphIndex(1)).toBe(1);
+    expect(string.stringIndexForGlyphIndex(2)).toBe(3);
+    expect(string.stringIndexForGlyphIndex(4)).toBe(5);
+    expect(string.stringIndexForGlyphIndex(5)).toBe(6);
+    expect(string.stringIndexForGlyphIndex(9)).toBe(10);
+  });
+
   test('should return correct string index for glyph index (non latin)', () => {
     const string = createCamboyanTestString({
       value: 'ខ្ញុំអាចញ៉ាំកញ្ចក់បាន',
@@ -810,6 +842,11 @@ describe('GlyphString', () => {
     // The new glyph shouldn't interfer with current indices
     expect(string.glyphRuns[0].stringIndices[2]).toBe(2);
     expect(string.glyphRuns[0].stringIndices[3]).toBe(2);
+
+    // Test glyph indices.
+    // Should increment glyph indices
+    expect(string.glyphRuns[0].glyphIndices[1]).toBe(1);
+    expect(string.glyphRuns[0].glyphIndices[2]).toBe(3);
   });
 
   test('should successfully insert glyph for sliced strings', () => {

--- a/packages/core/test/utils/glyphRuns.js
+++ b/packages/core/test/utils/glyphRuns.js
@@ -17,7 +17,7 @@ const getGlyphIndex = stringIndices => index => {
   Calculates position with fixed value based on if it's white space or not
 */
 const layout = value => {
-  const chars = value.replace(/fs/, 'f').split('');
+  const chars = value.split('');
   const glyphs = chars.map(char => ({ id: char.charCodeAt(0) }));
   const stringIndices = chars.map((_, index) => index);
   const glyphIndices = chars.map((_, index) => index);
@@ -102,6 +102,6 @@ export const createCamboyanTestRun = ({
     layout(string).glyphs,
     positions.slice(startGlyphIndex, endGlyphIndex),
     stringIndices.slice(startGlyphIndex, endGlyphIndex),
-    glyphIndices.slice(start, end)
+    glyphIndices.slice(start, end).map(i => i - glyphIndices[start])
   );
 };

--- a/packages/core/test/utils/glyphRuns.js
+++ b/packages/core/test/utils/glyphRuns.js
@@ -11,16 +11,51 @@ const getGlyphIndex = stringIndices => index => {
   return res;
 };
 
+const resolveGlyphIndices = (string, stringIndices) => {
+  const glyphIndices = [];
+
+  for (let i = 0; i < string.length; i++) {
+    for (let j = 0; j < stringIndices.length; j++) {
+      if (stringIndices[j] >= i) {
+        glyphIndices[i] = j;
+        break;
+      }
+
+      glyphIndices[i] = undefined;
+    }
+  }
+
+  let lastValue = glyphIndices[glyphIndices.length - 1];
+  for (let i = glyphIndices.length - 1; i >= 0; i--) {
+    if (glyphIndices[i] === undefined) {
+      glyphIndices[i] = lastValue;
+    } else {
+      lastValue = glyphIndices[i];
+    }
+  }
+
+  lastValue = glyphIndices[0];
+  for (let i = 0; i < glyphIndices.length; i++) {
+    if (glyphIndices[i] === undefined) {
+      glyphIndices[i] = lastValue;
+    } else {
+      lastValue = glyphIndices[i];
+    }
+  }
+
+  return glyphIndices;
+};
+
 /*
   Text layout generator.
   Calculates chars id based on the glyph code point only for testing purposes
   Calculates position with fixed value based on if it's white space or not
 */
-const layout = value => {
-  const chars = value.split('');
+export const layout = value => {
+  const chars = value.replace(/ft/, 'f').split('');
   const glyphs = chars.map(char => ({ id: char.charCodeAt(0) }));
-  const stringIndices = chars.map((_, index) => index);
-  const glyphIndices = chars.map((_, index) => index);
+  const stringIndices = chars.map((_, index) => value.indexOf(chars[index], index));
+  const glyphIndices = resolveGlyphIndices(value, stringIndices);
   const positions = chars.map(char => ({
     xAdvance: char === ' ' ? 512 : 1024
   }));

--- a/packages/core/test/utils/glyphRuns.js
+++ b/packages/core/test/utils/glyphRuns.js
@@ -17,9 +17,10 @@ const getGlyphIndex = stringIndices => index => {
   Calculates position with fixed value based on if it's white space or not
 */
 const layout = value => {
-  const chars = value.split('');
+  const chars = value.replace(/fs/, 'f').split('');
   const glyphs = chars.map(char => ({ id: char.charCodeAt(0) }));
   const stringIndices = chars.map((_, index) => index);
+  const glyphIndices = chars.map((_, index) => index);
   const positions = chars.map(char => ({
     xAdvance: char === ' ' ? 512 : 1024
   }));
@@ -27,7 +28,8 @@ const layout = value => {
   return {
     glyphs,
     positions,
-    stringIndices
+    stringIndices,
+    glyphIndices
   };
 };
 
@@ -43,9 +45,17 @@ export const createLatinTestRun = ({
 } = {}) => {
   const string = value.slice(start, end);
   const attrs = new RunStyle(Object.assign({}, { font: testFont }, attributes));
-  const { glyphs, positions, stringIndices } = layout(string);
+  const { glyphs, positions, stringIndices, glyphIndices } = layout(string);
 
-  return new GlyphRun(start, start + glyphs.length, attrs, glyphs, positions, stringIndices);
+  return new GlyphRun(
+    start,
+    start + glyphs.length,
+    attrs,
+    glyphs,
+    positions,
+    stringIndices,
+    glyphIndices
+  );
 };
 
 /*
@@ -60,6 +70,7 @@ export const createCamboyanTestRun = ({
   end = value.length
 } = {}) => {
   const stringIndices = [0, 1, 3, 4, 5, 6, 7, 8, 12, 13, 14, 16, 17, 18, 19, 20];
+  const glyphIndices = [0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 9, 10, 11, 11, 12, 13, 14, 15];
   const getIndex = getGlyphIndex(stringIndices);
   const startGlyphIndex = getIndex(start);
   const endGlyphIndex = getIndex(end);
@@ -90,6 +101,7 @@ export const createCamboyanTestRun = ({
     attrs,
     layout(string).glyphs,
     positions.slice(startGlyphIndex, endGlyphIndex),
-    stringIndices.slice(startGlyphIndex, endGlyphIndex)
+    stringIndices.slice(startGlyphIndex, endGlyphIndex),
+    glyphIndices.slice(start, end)
   );
 };

--- a/packages/core/test/utils/glyphStrings.js
+++ b/packages/core/test/utils/glyphStrings.js
@@ -1,16 +1,30 @@
+import RunStyle from '../../src/models/RunStyle';
+import GlyphRun from '../../src/models/GlyphRun';
 import GlyphString from '../../src/models/GlyphString';
-import { createLatinTestRun, createCamboyanTestRun } from './glyphRuns';
+import { layout, createCamboyanTestRun } from './glyphRuns';
+import testFont from './font';
 
 export const createLatinTestString = ({
   value = 'Lorem ipsum',
   runs = [[0, value.length]]
 } = {}) => {
+  let glyphIndex = 0;
+  const attrs = new RunStyle(Object.assign({}, { font: testFont }));
+
   const glyphRuns = runs.map(run => {
-    const glyphRun = createLatinTestRun({
-      value,
-      end: run[1],
-      start: run[0]
-    });
+    const { glyphs, positions, stringIndices, glyphIndices } = layout(value.slice(run[0], run[1]));
+
+    const glyphRun = new GlyphRun(
+      glyphIndex,
+      glyphIndex + glyphs.length,
+      attrs,
+      glyphs,
+      positions,
+      stringIndices,
+      glyphIndices
+    );
+
+    glyphIndex += glyphRun.length;
 
     return glyphRun;
   });

--- a/temp.js
+++ b/temp.js
@@ -28,16 +28,38 @@ doc.stroke();
 
 const string = AttributedString.fromFragments([
   {
-    string: '“Lorem ipsum dolor sit \ufffc amet, ',
+    string: 'Lorem ipsum dolor sit amet, ',
     attributes: {
       font: 'Arial',
       fontSize: 14,
       bold: true,
       align: 'justify',
-      attachment: new Attachment(14, 14, {
-        yOffset: 3,
-        image: './grinning.png'
-      })
+      hyphenationFactor: 0.9,
+      hangingPunctuation: true,
+      lineSpacing: 5,
+      truncate: true
+    }
+  },
+  {
+    string: 'consectetur adipiscing elit, ',
+    attributes: {
+      font: 'Arial',
+      fontSize: 18,
+      color: 'red',
+      align: 'justify'
+    }
+  },
+  {
+    string:
+      'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea volupt\u0301ate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?”',
+    attributes: {
+      font: 'Comic Sans MS',
+      fontSize: 14,
+      align: 'justify',
+      hyphenationFactor: 0.9,
+      hangingPunctuation: true,
+      lineSpacing: 5,
+      truncate: true
     }
   }
 ]);


### PR DESCRIPTION
In here I'm trying to solve an scenario I'm getting, which is  having a ligature at the end of a GlyphRun. In this case, the stringIndices does not reflect this fact, which makes the glyphIndices also wrong. Since inside the GlyphRun class I not longer have access to the original string, I now resolve the glyphIndices outside and pass them via the constructor.