### PR TITLE
Enhance build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,35 @@
 {
-  "presets": ["es2015", "stage-0"],
-  "plugins": ["transform-class-properties", "transform-export-extensions"]
+  "presets": [
+    ["env", {
+      "loose": true,
+      "targets": {
+        "browsers": [
+          "> 0.05%",
+          "not dead",
+          "not ie 11",
+          "not android 4.1",
+          "not android 4.2",
+          "not android 4.4",
+          "not android 4.4.3",
+          "not chrome 29",
+          "not chrome 43",
+          "not chrome 49",
+          "not chrome 54",
+          "not firefox 47",
+          "not firefox 48",
+          "not firefox 51",
+          "not firefox 52",
+          "not ios 8.1",
+          "not ios 9.3",
+          "not safari 5.1",
+          "not safari 9.1"
+        ]
+      }
+    }]
+  ],
+  "plugins": [
+    "transform-runtime",
+    "transform-export-extensions",
+    ["transform-class-properties", { "loose": true }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -19,16 +19,17 @@
     "access": "public"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "pdfkit": "^0.8.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",
-    "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.7.0",
     "eslint": "^4.18.2",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",


### PR DESCRIPTION
Use `babel-preset-env` to make build. This will only apply the proper transformations to make the lib work in most modern browsers, for ex, not depending on babel `regeneratorRuntime` that creates much overhead. Reference: https://twitter.com/jamiebuilds/status/1022568918949408768

Also uses `babel-runtime` to avoid repeated babel code in builds