### PR TITLE
Apply character spacing

### DIFF
--- a/packages/core/src/models/GlyphRun.js
+++ b/packages/core/src/models/GlyphRun.js
@@ -11,12 +11,17 @@ class GlyphRun extends Run {
     this.scale = attributes.fontSize / attributes.font.unitsPerEm;
 
     if (!preScaled) {
-      for (const pos of this.positions) {
-        pos.xAdvance *= this.scale;
+      this.positions.forEach((pos, index) => {
+        const xAdvance =
+          index === this.positions.length - 1
+            ? pos.xAdvance * this.scale
+            : pos.xAdvance * this.scale + attributes.characterSpacing;
+
+        pos.xAdvance = xAdvance;
         pos.yAdvance *= this.scale;
         pos.xOffset *= this.scale;
         pos.yOffset *= this.scale;
-      }
+      });
     }
   }
 

--- a/packages/core/test/models/GlyphRun.test.js
+++ b/packages/core/test/models/GlyphRun.test.js
@@ -94,6 +94,21 @@ describe('GlyphRun', () => {
     expect(glyphRun.height).toBe(expectedHeight);
   });
 
+  test('should get character spacing correctly', () => {
+    // xAdvances without character spacing:
+    //  L   o   r   e   m
+    //  10  10  10  10  10
+
+    const fontSize = 20;
+    const characterSpacing = 10;
+    const glyphRun = createLatinTestRun({
+      value: 'Lorem',
+      attributes: { fontSize, characterSpacing }
+    });
+
+    expect(glyphRun.positions.map(p => p.xAdvance)).toEqual([20, 20, 20, 20, 10]);
+  });
+
   test('should exact slice range return same run', () => {
     const glyphRun = createLatinTestRun({ value: 'Lorem Ipsum' });
     const sliced = glyphRun.slice(0, 11);


### PR DESCRIPTION
Applies `characterSpacing` to glyphs when provided. Because spacing is added after each glyph, it is not applied to the last glyph.

Hoping to use this to add `letterSpacing` to `react-pdf` as suggested here: https://github.com/diegomura/react-pdf/issues/241 (I think this commit is all that will be needed: https://github.com/asmockler/react-pdf/commit/a9ab5f57340a35fe85898174483ef92bb059506c)